### PR TITLE
Added TraceLevel to hook

### DIFF
--- a/logrus_lumberjack.go
+++ b/logrus_lumberjack.go
@@ -43,6 +43,7 @@ func (hook *LumberjackHook) Fire(entry *logrus.Entry) error {
 // Levels returns the available logging levels
 func (hook *LumberjackHook) Levels() []logrus.Level {
   return []logrus.Level{
+    logrus.TraceLevel,
     logrus.DebugLevel,
     logrus.InfoLevel,
     logrus.WarnLevel,


### PR DESCRIPTION
I'm not sure if there is a specific reason for `logrus.TraceLevel` to be absent from the `Levels()` function but it means that trace level logging is not written to lumberjack log files.